### PR TITLE
fixed long name stretching result view

### DIFF
--- a/AdoptMe/View/SearchView/SearchResultView.swift
+++ b/AdoptMe/View/SearchView/SearchResultView.swift
@@ -33,6 +33,7 @@ struct SearchResultView: View {
             VStack(alignment: .leading) {
                 HStack {
                     Text(animal.name).font(.headline)
+                        .lineLimit(2)
                     Spacer()
                     Button {
                         if adoptMe.favorites.contains(animal.id) {

--- a/AdoptMe/View/SearchView/SearchResultView.swift
+++ b/AdoptMe/View/SearchView/SearchResultView.swift
@@ -33,7 +33,7 @@ struct SearchResultView: View {
             VStack(alignment: .leading) {
                 HStack {
                     Text(animal.name).font(.headline)
-                        .lineLimit(2)
+                        .lineLimit(1)
                     Spacer()
                     Button {
                         if adoptMe.favorites.contains(animal.id) {
@@ -51,6 +51,7 @@ struct SearchResultView: View {
                 Text(animal.breeds?.primary ?? "").font(.subheadline)
                 Spacer()
                 Text(organization.name).font(.headline)
+                    .lineLimit(2)
             }.padding(4.0)
         }.padding(12.0)
     }


### PR DESCRIPTION
Long names would stretch the search result view past the regular height. There is now a line limit of 1 for the animal name and 2 for the organization name